### PR TITLE
Update styling & formatting of numbers in the equations

### DIFF
--- a/assets/js/drawing-functions.js
+++ b/assets/js/drawing-functions.js
@@ -66,9 +66,8 @@ function updateMatrixValues(symbol, variable) {
   // TODO: instead of toFixed(2), use toFixed(slider.decimals) after OOP refactoring..
 
   // Update the values in the matrix & the quations
-  // - Note: function formatNumber() is defined in levels.js
   document.getElementById('matrix-' + symbol).innerText = newValue;
-  document.getElementById('equation-' + symbol).innerText = formatNumber(newValue, variable);
+  document.getElementById('equation-' + symbol).innerText = newValue;
 
 }
 

--- a/assets/js/levels.js
+++ b/assets/js/levels.js
@@ -137,34 +137,12 @@ function loadInitialValues(index) {
     matrixD.innerText = d;
     matrixE.innerText = e;
     matrixF.innerText = f;
-    equationA.innerText = formatNumber(a, "x");
-    equationB.innerText = formatNumber(b, "x");
-    equationC.innerText = formatNumber(c, "y");
-    equationD.innerText = formatNumber(d, "y");
+    equationA.innerText = a;
+    equationB.innerText = b;
+    equationC.innerText = c;
+    equationD.innerText = d;
     equationE.innerText = e;
     equationF.innerText = f;
-  }
-}
-
-// Small helper function for formatting numbers in the equations
-// A) Example: formatNumber(a, "x");
-//    - returns "0" when a = 0
-//    - returns "x" when a = 1
-//    - returns "(-8)x" when a = -8
-//    - returns "8x" when a = 8
-//    - returns "-x" when a = -1
-// B) Set variable as empty string "" when there's no need to append a variable to it
-function formatNumber(number, variable) {
-  if (number === 0) {
-    return "0";
-  } else if (number === 1) {
-    return variable;
-  } else if (number === -1) {
-    return "(-" + variable + ")";
-  } else if (number < 0) {
-    return "(" + number + ")" + variable;
-  } else {
-    return (number + variable);
   }
 }
 

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -360,16 +360,13 @@ select:focus {
 
 /* ------------------- Matrix values ------------------- */
 
-#bottom-half .matrix-values .highlighted {
-  color: rgba(246, 84, 133, 1);
-}
-
 #bottom-half .matrix {
   width: 160px;
   height: 120px;
   padding: 10px;
   position: relative;
   margin-bottom: 40px;
+  font-size: 14px;
 }
 
 #bottom-half .matrix .bracket {
@@ -403,12 +400,28 @@ select:focus {
   font-style: italic;
 }
 
+#bottom-half .matrix .highlighted {
+  color: rgba(246, 84, 133, 1);
+}
+
 #bottom-half .equations {
   font-style: italic;
   min-width: 135px;
+  font-size: 14px;
 }
 
 #bottom-half .equations .row-2,
 #bottom-half .equations .row-4 {
   padding-left: 16px;
+}
+
+#bottom-half .equations .highlighted {
+  background-color: rgba(246, 84, 133, 0.1);
+  color: rgba(246, 84, 133, 1);
+  border-radius: 4px;
+  padding: 0 3px;
+  margin-right: 2px;
+  display: inline-block;
+  min-width: 48px;
+  text-align: center;
 }

--- a/index.html
+++ b/index.html
@@ -68,9 +68,9 @@
               </div>
               <div class="equations">
                 <p>x’  =  ax  +  cy  +  e</p>
-                <p class="row-2">=  <span id="equation-a"></span>  +  <span id="equation-c"></span>  +  <span id="equation-e"></span></p>
+                <p class="row-2">=  <span id="equation-a"></span>x  +  <span id="equation-c"></span>y  +  <span id="equation-e"></span></p>
                 <p>y’  =  bx  +  dy  +  f</p>
-                <p class="row-4">=  <span id="equation-b"></span>  +  <span id="equation-d"></span>  +  <span id="equation-f"></span></p>
+                <p class="row-4">=  <span id="equation-b"></span>x  +  <span id="equation-d"></span>y  +  <span id="equation-f"></span></p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
- use a container with fixed width to contain highlighted numbers in the equations
- remove number formatting (e.g. 1*x displays as 1x instead of x)
- fixes #17